### PR TITLE
Introduce idempotency

### DIFF
--- a/src/main/kotlin/nl/fayece/paymentprocessing/config/JacksonConfig.kt
+++ b/src/main/kotlin/nl/fayece/paymentprocessing/config/JacksonConfig.kt
@@ -1,0 +1,14 @@
+package nl.fayece.paymentprocessing.config
+
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class JacksonConfig {
+
+    @Bean
+    fun objectMapper(): ObjectMapper = JsonMapper.builder().findAndAddModules().build()
+}

--- a/src/main/kotlin/nl/fayece/paymentprocessing/controllers/PaymentController.kt
+++ b/src/main/kotlin/nl/fayece/paymentprocessing/controllers/PaymentController.kt
@@ -5,11 +5,13 @@ import nl.fayece.paymentprocessing.domain.Iban
 import nl.fayece.paymentprocessing.dto.payments.PaymentRequest
 import nl.fayece.paymentprocessing.dto.payments.PaymentResponse
 import nl.fayece.paymentprocessing.dto.payments.ReversePaymentRequest
+import nl.fayece.paymentprocessing.services.IdempotencyService
 import nl.fayece.paymentprocessing.services.PaymentService
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -18,41 +20,73 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/payments")
-class PaymentController(private val paymentService: PaymentService) {
+class PaymentController(
+    private val paymentService: PaymentService,
+    private val idempotencyService: IdempotencyService
+) {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun submitPayment(@Valid @RequestBody request: PaymentRequest): PaymentResponse {
-        val args = request.toArgs()
-        val transaction = paymentService.submitPayment(
-            sourceIban = args.sourceIban,
-            destinationIban = args.destinationIban,
-            amount = args.amount,
-            currency = args.currency
-        )
+    fun submitPayment(
+        @RequestHeader("Idempotency-Key") idempotencyKey: String,
+        @Valid @RequestBody request: PaymentRequest
+    ): PaymentResponse {
+        // Generate a unique transaction ID.
+        // On idempotency conflict, this ID will be safely ignored.
+        val transactionId = UUID.randomUUID()
 
-        return PaymentResponse.from(transaction)
+        return idempotencyService.resolve(idempotencyKey, transactionId, PaymentResponse::class.java) {
+            val args = request.toArgs()
+            val transaction = paymentService.submitPayment(
+                sourceIban = args.sourceIban,
+                destinationIban = args.destinationIban,
+                amount = args.amount,
+                currency = args.currency
+            )
+            PaymentResponse.from(transaction)
+        }
     }
 
     // Webhook, externally triggered when the settlement is confirmed by the system that handles it.
     @PostMapping("/{id}/confirm-settlement")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun confirmSettlement(@PathVariable id: UUID) {
-        paymentService.handleSettlementConfirmation(id)
+    fun confirmSettlement(
+        @RequestHeader("Idempotency-Key") idempotencyKey: String,
+        @PathVariable id: UUID
+    ) {
+        if (!idempotencyService.exists(idempotencyKey)) {
+            paymentService.handleSettlementConfirmation(id)
+            idempotencyService.record(idempotencyKey, id)
+        }
+
     }
 
     @PostMapping("/{id}/refund")
     @ResponseStatus(HttpStatus.CREATED)
-    fun refundPayment(@PathVariable id: UUID): PaymentResponse {
-        val transaction = paymentService.refundPayment(id)
-        return PaymentResponse.from(transaction)
+    fun refundPayment(
+        @RequestHeader("Idempotency-Key") idempotencyKey: String,
+        @PathVariable id: UUID
+    ): PaymentResponse {
+
+        return idempotencyService.resolve(idempotencyKey, id, PaymentResponse::class.java) {
+
+            val transaction = paymentService.refundPayment(id)
+            PaymentResponse.from(transaction)
+        }
     }
 
     @PostMapping("/{id}/reverse")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun reversePayment(@PathVariable id: UUID,
-                       @Valid @RequestBody request: ReversePaymentRequest) {
-        val args = request.toArgs()
-        paymentService.reversePayment(id, args.requesterIban)
+    fun reversePayment(
+        @RequestHeader("Idempotency-Key") idempotencyKey: String,
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: ReversePaymentRequest
+    ) {
+
+        if (!idempotencyService.exists(idempotencyKey)) {
+            val args = request.toArgs()
+            paymentService.reversePayment(id, args.requesterIban)
+            idempotencyService.record(idempotencyKey, id)
+        }
     }
 }

--- a/src/main/kotlin/nl/fayece/paymentprocessing/exceptions/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/nl/fayece/paymentprocessing/exceptions/GlobalExceptionHandler.kt
@@ -6,11 +6,13 @@ import nl.fayece.paymentprocessing.domain.exceptions.InsufficientBalanceExceptio
 import nl.fayece.paymentprocessing.domain.exceptions.InvalidIbanException
 import nl.fayece.paymentprocessing.domain.exceptions.InvalidTransactionStateException
 import nl.fayece.paymentprocessing.domain.exceptions.UnauthorizedOperationException
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
@@ -18,176 +20,75 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice
 class GlobalExceptionHandler {
 
+    private val logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
     @ExceptionHandler(InvalidTransactionStateException::class)
-    fun handleInvalidTransactionState(
-        ex: InvalidTransactionStateException,
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT).body(
-            ErrorResponse(
-                status = HttpStatus.UNPROCESSABLE_CONTENT.value(),
-                error = HttpStatus.UNPROCESSABLE_CONTENT.reasonPhrase,
-                message = ex.message ?: "Invalid transaction state transition",
-                path = request.requestURI
-            )
-        )
+    fun handleInvalidTransactionState(ex: InvalidTransactionStateException, request: HttpServletRequest) =
+        error(HttpStatus.UNPROCESSABLE_CONTENT, ex.message ?: "Invalid transaction state transition", request)
 
     @ExceptionHandler(InsufficientBalanceException::class)
-    fun handleInsufficientBalance(
-        ex: InsufficientBalanceException,
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT).body(
-            ErrorResponse(
-                status = HttpStatus.UNPROCESSABLE_CONTENT.value(),
-                error = HttpStatus.UNPROCESSABLE_CONTENT.reasonPhrase,
-                message = ex.message ?: "Insufficient balance",
-                path = request.requestURI
-            )
-        )
+    fun handleInsufficientBalance(ex: InsufficientBalanceException, request: HttpServletRequest) =
+        error(HttpStatus.UNPROCESSABLE_CONTENT, ex.message ?: "Insufficient balance", request)
 
     @ExceptionHandler(InvalidIbanException::class)
-    fun handleInvalidIban(
-        ex: InvalidIbanException,
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-            ErrorResponse(
-                status = HttpStatus.BAD_REQUEST.value(),
-                error = HttpStatus.BAD_REQUEST.reasonPhrase,
-                message = ex.message ?: "Invalid IBAN",
-                path = request.requestURI
-            )
-        )
+    fun handleInvalidIban(ex: InvalidIbanException, request: HttpServletRequest) =
+        error(HttpStatus.BAD_REQUEST, ex.message ?: "Invalid IBAN", request)
 
     @ExceptionHandler(UnauthorizedOperationException::class)
-    fun handleUnauthorizedOperation(
-        ex: UnauthorizedOperationException,
-        request:HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.FORBIDDEN).body(
-            ErrorResponse(
-                status = HttpStatus.FORBIDDEN.value(),
-                error = HttpStatus.FORBIDDEN.reasonPhrase,
-                message = ex.message ?: "You do not have permission to perform this operation",
-                path = request.requestURI
-            )
-        )
+    fun handleUnauthorizedOperation(ex: UnauthorizedOperationException, request: HttpServletRequest) =
+        error(HttpStatus.FORBIDDEN, ex.message ?: "You do not have permission to perform this operation", request)
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidationErrors(
-        ex: MethodArgumentNotValidException,
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> {
-        val fieldViolations = ex.bindingResult.fieldErrors.map { error ->
-            FieldViolation(
-                field = error.field,
-                message = error.defaultMessage ?: "Invalid value"
-            )
-        }
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-            ErrorResponse(
-                status = HttpStatus.BAD_REQUEST.value(),
-                error = HttpStatus.BAD_REQUEST.reasonPhrase,
-                message = "Validation failed",
-                path = request.requestURI,
-                fields = fieldViolations
-            )
-        )
+    fun handleValidationErrors(ex: MethodArgumentNotValidException, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
+        val fieldViolations = ex.bindingResult.fieldErrors.map { FieldViolation(it.field, it.defaultMessage ?: "Invalid value") }
+        return error(HttpStatus.BAD_REQUEST, "Validation failed", request, fieldViolations)
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException::class)
-    fun handleTypeMismatch(
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> = ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-        ErrorResponse(
-            status = HttpStatus.BAD_REQUEST.value(),
-            error = HttpStatus.BAD_REQUEST.reasonPhrase,
-            message = "Invalid type for request parameter",
-            path = request.requestURI
-        )
-    )
+    fun handleTypeMismatch(ex: MethodArgumentTypeMismatchException, request: HttpServletRequest) =
+        error(HttpStatus.BAD_REQUEST, "Invalid type for request parameter", request)
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleUnreadableMessage(
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-            ErrorResponse(
-                status = HttpStatus.BAD_REQUEST.value(),
-                error = HttpStatus.BAD_REQUEST.reasonPhrase,
-                message = "Malformed or unreadable request body",
-                path = request.requestURI
-            )
-        )
+    fun handleUnreadableMessage(ex: HttpMessageNotReadableException, request: HttpServletRequest) =
+        error(HttpStatus.BAD_REQUEST, "Malformed or unreadable request body", request)
 
     @ExceptionHandler(NoSuchElementException::class)
-    fun handleNotFound(
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-            ErrorResponse(
-                status = HttpStatus.NOT_FOUND.value(),
-                error = HttpStatus.NOT_FOUND.reasonPhrase,
-                message = "Resource not found",
-                path = request.requestURI
-            )
-        )
+    fun handleNotFound(ex: NoSuchElementException, request: HttpServletRequest) =
+        error(HttpStatus.NOT_FOUND, "Resource not found", request)
 
     @ExceptionHandler(IllegalArgumentException::class)
-    fun handleBadRequest(
-        ex: IllegalArgumentException,
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-            ErrorResponse(
-                status = HttpStatus.BAD_REQUEST.value(),
-                error = HttpStatus.BAD_REQUEST.reasonPhrase,
-                message = ex.message ?: "Bad request",
-                path = request.requestURI
-            )
-        )
+    fun handleBadRequest(ex: IllegalArgumentException, request: HttpServletRequest) =
+        error(HttpStatus.BAD_REQUEST, ex.message ?: "Bad request", request)
 
     @ExceptionHandler(EntityNotFoundException::class)
-    fun handleEntityNotFound(
-        ex: EntityNotFoundException,
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-            ErrorResponse(
-                status = HttpStatus.NOT_FOUND.value(),
-                error = HttpStatus.NOT_FOUND.reasonPhrase,
-                message = ex.message ?: "Entity not found",
-                path = request.requestURI
-            )
-        )
+    fun handleEntityNotFound(ex: EntityNotFoundException, request: HttpServletRequest) =
+        error(HttpStatus.NOT_FOUND, ex.message ?: "Entity not found", request)
+
+    @ExceptionHandler(MissingRequestHeaderException::class)
+    fun handleMissingHeader(ex: MissingRequestHeaderException, request: HttpServletRequest) =
+        error(HttpStatus.BAD_REQUEST, "Required header '${ex.headerName}' is missing", request)
 
     @ExceptionHandler(ObjectOptimisticLockingFailureException::class)
-    fun handleOptimisticLockingFailure(
-        ex: ObjectOptimisticLockingFailureException,
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
-            .header("Retry-After", "1")
-            .body(
-                ErrorResponse(
-                    status = HttpStatus.SERVICE_UNAVAILABLE.value(),
-                    error = HttpStatus.SERVICE_UNAVAILABLE.reasonPhrase,
-                    message = ex.message ?: "Service temporarily unavailable. Please try again later.",
-                    path = request.requestURI
-                )
-            )
+    fun handleOptimisticLockingFailure(ex: ObjectOptimisticLockingFailureException, request: HttpServletRequest) =
+        error(HttpStatus.SERVICE_UNAVAILABLE, ex.message ?: "Service temporarily unavailable. Please try again later.", request)
+            .also { it.headers.set("Retry-After", "1") }
 
     @ExceptionHandler(Exception::class)
-    fun handleException(
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> =
-        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+    fun handleException(ex: Exception, request: HttpServletRequest) {
+        logger.error("Unhandled exception on ${request.method} ${request.requestURI}", ex)
+        error(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred. Please try again later.", request)
+//         error(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred. Please try again later.", request)
+    }
+
+
+    private fun error(status: HttpStatus, message: String, request: HttpServletRequest, fields: List<FieldViolation>? = null) =
+        ResponseEntity.status(status).body(
             ErrorResponse(
-                status = HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                error = HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase,
-                message = "An unexpected error occurred. Please try again later.",
-                path = request.requestURI
+                status = status.value(),
+                error = status.reasonPhrase,
+                message = message,
+                path = request.requestURI,
+                fields = fields
             )
         )
 }

--- a/src/main/kotlin/nl/fayece/paymentprocessing/repositories/IdempotencyKeyRepository.kt
+++ b/src/main/kotlin/nl/fayece/paymentprocessing/repositories/IdempotencyKeyRepository.kt
@@ -2,5 +2,9 @@ package nl.fayece.paymentprocessing.repositories
 
 import nl.fayece.paymentprocessing.domain.IdempotencyKey
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
 
-interface IdempotencyKeyRepository : JpaRepository<IdempotencyKey, String>
+interface IdempotencyKeyRepository : JpaRepository<IdempotencyKey, String> {
+
+    fun findByKey(key: String): Optional<IdempotencyKey>
+}

--- a/src/main/kotlin/nl/fayece/paymentprocessing/services/IdempotencyService.kt
+++ b/src/main/kotlin/nl/fayece/paymentprocessing/services/IdempotencyService.kt
@@ -1,0 +1,45 @@
+package nl.fayece.paymentprocessing.services
+
+import tools.jackson.databind.ObjectMapper
+import nl.fayece.paymentprocessing.domain.IdempotencyKey
+import nl.fayece.paymentprocessing.repositories.IdempotencyKeyRepository
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class IdempotencyService (
+    private val idemPotencyRepository: IdempotencyKeyRepository,
+    private val objectMapper: ObjectMapper
+) {
+    fun <T: Any> resolve(key: String, transactionId: UUID, responseClass: Class<T>, block: () -> T): T {
+
+        val existing = idemPotencyRepository.findByKey(key)
+
+        if (existing.isPresent) {
+            return objectMapper.readValue(existing.get().responseSnapshot, responseClass)
+        }
+
+        val result = block()
+        idemPotencyRepository.save(
+            IdempotencyKey(
+                key = key,
+                transactionId = transactionId,
+                responseSnapshot = objectMapper.writeValueAsString(result)
+            )
+        )
+
+        return result
+    }
+
+    fun record(key: String, transactionId: UUID) {
+        idemPotencyRepository.save(
+            IdempotencyKey(
+                key = key,
+                transactionId = transactionId,
+                responseSnapshot = "{}"
+            )
+        )
+    }
+
+    fun exists(key: String): Boolean = idemPotencyRepository.findByKey(key).isPresent
+}

--- a/src/main/kotlin/nl/fayece/paymentprocessing/services/PaymentService.kt
+++ b/src/main/kotlin/nl/fayece/paymentprocessing/services/PaymentService.kt
@@ -14,8 +14,8 @@ import nl.fayece.paymentprocessing.repositories.TransactionRepository
 import nl.fayece.paymentprocessing.repositories.TransactionStatusHistoryRepository
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.resilience.annotation.Retryable
-import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.util.Currency
@@ -25,7 +25,8 @@ import java.util.UUID
 class PaymentService (
     private val accountRepository: AccountRepository,
     private val transactionRepository: TransactionRepository,
-    private val statusHistoryRepository: TransactionStatusHistoryRepository
+    private val statusHistoryRepository: TransactionStatusHistoryRepository,
+    private val transactionHistoryWriter: TransactionHistoryWriter
 ) {
     @Retryable(
         includes = [ObjectOptimisticLockingFailureException::class],
@@ -172,7 +173,8 @@ class PaymentService (
         } catch (e: Exception) {
             if (e is ObjectOptimisticLockingFailureException) throw e
 
-            transition(transaction, TransactionStatus.FAILED, e.message)
+            transaction.transitionTo(TransactionStatus.FAILED)
+            transactionHistoryWriter.recordFailure(transaction, e.message)
             throw e
         }
 

--- a/src/main/kotlin/nl/fayece/paymentprocessing/services/TransactionHistoryWriter.kt
+++ b/src/main/kotlin/nl/fayece/paymentprocessing/services/TransactionHistoryWriter.kt
@@ -1,0 +1,28 @@
+package nl.fayece.paymentprocessing.services
+
+import nl.fayece.paymentprocessing.domain.Transaction
+import nl.fayece.paymentprocessing.domain.TransactionStatus
+import nl.fayece.paymentprocessing.domain.TransactionStatusHistory
+import nl.fayece.paymentprocessing.repositories.TransactionRepository
+import nl.fayece.paymentprocessing.repositories.TransactionStatusHistoryRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class TransactionHistoryWriter(
+    private val transactionRepository: TransactionRepository,
+    private val statusHistoryRepository: TransactionStatusHistoryRepository
+) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun recordFailure(transaction: Transaction, reason: String?) {
+        transactionRepository.save(transaction)
+        statusHistoryRepository.save(
+            TransactionStatusHistory(
+                transaction = transaction,
+                status = TransactionStatus.FAILED,
+                reason = reason
+            )
+        )
+    }
+}

--- a/src/test/kotlin/nl/fayece/paymentprocessing/controllers/AuditControllerTest.kt
+++ b/src/test/kotlin/nl/fayece/paymentprocessing/controllers/AuditControllerTest.kt
@@ -32,8 +32,6 @@ class AuditControllerTest {
     @MockkBean
     lateinit var paymentService: PaymentService
 
-    private val objectMapper = ObjectMapper().findAndRegisterModules()
-
     private val eur = Currency.getInstance("EUR")
     private val sourceIban = Iban.of("NL13TEST0123456789")
     private val destinationIban = Iban.of("NL65TEST0987656789")

--- a/src/test/kotlin/nl/fayece/paymentprocessing/controllers/PaymentControllerTest.kt
+++ b/src/test/kotlin/nl/fayece/paymentprocessing/controllers/PaymentControllerTest.kt
@@ -8,9 +8,12 @@ import nl.fayece.paymentprocessing.domain.*
 import nl.fayece.paymentprocessing.domain.exceptions.InvalidTransactionStateException
 import nl.fayece.paymentprocessing.domain.exceptions.UnauthorizedOperationException
 import nl.fayece.paymentprocessing.dto.payments.PaymentRequest
+import nl.fayece.paymentprocessing.dto.payments.PaymentResponse
 import nl.fayece.paymentprocessing.dto.payments.ReversePaymentRequest
+import nl.fayece.paymentprocessing.services.IdempotencyService
 import nl.fayece.paymentprocessing.services.PaymentService
 import nl.fayece.paymentprocessing.util.toMoney
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -32,12 +35,15 @@ class PaymentControllerTest {
     @MockkBean
     lateinit var paymentService: PaymentService
 
+    @MockkBean
+    lateinit var idempotencyService: IdempotencyService
+
     private val objectMapper = ObjectMapper().findAndRegisterModules()
 
     private val eur = Currency.getInstance("EUR")
     private val sourceIban = Iban.of("NL13TEST0123456789")
     private val destinationIban = Iban.of("NL65TEST0987656789")
-
+    private val idempotencyKey = "test-idempotency-key"
 
     private val sourceAccount = Account(name = "Alice", iban = sourceIban, balance = BigDecimal("500.00").toMoney())
     private val destinationAccount = Account(name = "Bob", iban = destinationIban, balance = BigDecimal("100.00").toMoney())
@@ -61,6 +67,19 @@ class PaymentControllerTest {
         it.transitionTo(TransactionStatus.SETTLED)
     }
 
+    @BeforeEach
+    fun setupIdempotencyInit() {
+
+        every { idempotencyService.resolve(
+            eq(idempotencyKey), any(), eq(PaymentResponse::class.java), any<() -> PaymentResponse>()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            (args[3] as () -> PaymentResponse).invoke()
+        }
+
+        every { idempotencyService.exists(any()) } returns false
+        every { idempotencyService.record(any(), any()) } just Runs
+    }
+
     @Nested
     inner class SubmitPayment {
 
@@ -72,6 +91,7 @@ class PaymentControllerTest {
                 every { paymentService.submitPayment(any(), any(), any(), any())} returns queuedTransaction()
 
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest)
                 }.andExpect {
@@ -88,11 +108,45 @@ class PaymentControllerTest {
         }
 
         @Nested
+        inner class Idempotency {
+
+            @Test
+            fun `returns 400 when idempotency key is missing`() {
+                mockMvc.post("/api/payments") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(validRequest)
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.message") { value("Required header 'Idempotency-Key' is missing") }
+                }
+            }
+
+            @Test
+            fun `returns cached response on duplicate key without reprocessing`() {
+                val cachedResponse = PaymentResponse.from(queuedTransaction())
+                every { idempotencyService.resolve(
+                    eq(idempotencyKey), any(), PaymentResponse::class.java, any<() -> PaymentResponse>()) } returns cachedResponse
+
+                mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(validRequest)
+                }.andExpect {
+                    status { isCreated() }
+                    jsonPath("$.transactionId") { value(cachedResponse.transactionId.toString()) }
+                }
+
+                verify(exactly = 0) { paymentService.submitPayment(any(), any(), any(), any()) }
+            }
+        }
+
+        @Nested
         inner class Validation {
 
             @Test
             fun `returns 400 when source IBAN format is invalid`() {
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest.copy(sourceIban = "INVALID"))
                 }.andExpect {
@@ -105,6 +159,7 @@ class PaymentControllerTest {
             @Test
             fun `returns 400 when destination IBAN format is invalid`() {
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest.copy(destinationIban = "INVALID"))
                 }.andExpect {
@@ -117,6 +172,7 @@ class PaymentControllerTest {
             @Test
             fun `returns 400 when source IBAN is blank`() {
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest.copy(sourceIban = ""))
                 }.andExpect {
@@ -128,6 +184,7 @@ class PaymentControllerTest {
             @Test
             fun `returns 400 when destination IBAN is blank`() {
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest.copy(destinationIban = ""))
                 }.andExpect {
@@ -148,6 +205,7 @@ class PaymentControllerTest {
                 """.trimIndent()
 
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = requestWithNullAmount
                 }.andExpect {
@@ -159,6 +217,7 @@ class PaymentControllerTest {
             @Test
             fun `returns 400 when amount is zero`() {
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest.copy(amount = BigDecimal.ZERO))
                 }.andExpect {
@@ -170,6 +229,7 @@ class PaymentControllerTest {
             @Test
             fun `returns 400 when amount is negative`() {
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest.copy(amount = BigDecimal("-10.00")))
                 }.andExpect {
@@ -181,6 +241,7 @@ class PaymentControllerTest {
             @Test
             fun `returns 400 when currency is blank`() {
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest.copy(currency = ""))
                 }.andExpect {
@@ -192,6 +253,7 @@ class PaymentControllerTest {
             @Test
             fun `returns 400 with all field errors when multiple fields are invalid`() {
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(
                         validRequest.copy(sourceIban = "INVALID", amount = BigDecimal.ZERO)
@@ -210,6 +272,7 @@ class PaymentControllerTest {
                         IllegalArgumentException("Payment amount must be positive")
 
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest)
                 }.andExpect {
@@ -224,6 +287,7 @@ class PaymentControllerTest {
                         EntityNotFoundException("Account not found: ${sourceIban.value}")
 
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest)
                 }.andExpect {
@@ -242,6 +306,7 @@ class PaymentControllerTest {
                         ObjectOptimisticLockingFailureException(Account::class.java, "test-id")
 
                 mockMvc.post("/api/payments") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest)
                 }.andExpect {
@@ -264,11 +329,43 @@ class PaymentControllerTest {
                 every { paymentService.handleSettlementConfirmation(transactionId) } just Runs
 
                 mockMvc.post("/api/payments/$transactionId/confirm-settlement") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest)
                 }.andExpect {
                     status { isNoContent() }
                 }
+            }
+        }
+
+        @Nested
+        inner class Idempotency {
+
+            @Test
+            fun `returns 400 when idempotency key is missing`() {
+                val transactionId = UUID.randomUUID()
+
+                mockMvc.post("/api/payments/$transactionId/confirm-settlement") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(validRequest)
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.message") { value("Required header 'Idempotency-Key' is missing") }
+                }
+            }
+
+            @Test
+            fun `returns 204 on duplicate key without reprocessing`() {
+                val transactionId = UUID.randomUUID()
+                every { idempotencyService.exists(idempotencyKey) } returns true
+
+                mockMvc.post("/api/payments/$transactionId/confirm-settlement") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isNoContent() }
+                }
+
+                verify(exactly = 0) { paymentService.handleSettlementConfirmation(any()) }
             }
         }
 
@@ -279,10 +376,11 @@ class PaymentControllerTest {
             fun `returns 400 when transaction ID is invalid`() {
                 val invalidId = "invalid-id"
 
-                mockMvc.post("/api/payments/$invalidId/confirm-settlement")
-                    .andExpect {
-                        status { isBadRequest() }
-                    }
+                mockMvc.post("/api/payments/$invalidId/confirm-settlement") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isBadRequest() }
+                }
 
             }
 
@@ -292,10 +390,11 @@ class PaymentControllerTest {
                 every { paymentService.handleSettlementConfirmation(unknownId) } throws
                         EntityNotFoundException("Transaction not found: $unknownId")
 
-                mockMvc.post("/api/payments/$unknownId/confirm-settlement")
-                    .andExpect {
-                        status { isNotFound() }
-                    }
+                mockMvc.post("/api/payments/$unknownId/confirm-settlement") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isNotFound() }
+                }
             }
 
             @Test
@@ -304,10 +403,11 @@ class PaymentControllerTest {
                 every { paymentService.handleSettlementConfirmation(transactionId) } throws
                         InvalidTransactionStateException("Transaction is not in a valid state for settlement")
 
-                mockMvc.post("/api/payments/$transactionId/confirm-settlement")
-                    .andExpect {
-                        status { isUnprocessableContent() }
-                    }
+                mockMvc.post("/api/payments/$transactionId/confirm-settlement") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isUnprocessableContent() }
+                }
             }
 
             @Test
@@ -316,11 +416,12 @@ class PaymentControllerTest {
                 every { paymentService.handleSettlementConfirmation(transactionId) } throws
                         ObjectOptimisticLockingFailureException(Transaction::class.java, "test-id")
 
-                mockMvc.post("/api/payments/$transactionId/confirm-settlement")
-                    .andExpect {
-                        status { isServiceUnavailable() }
-                        header { string("Retry-After", "1") }
-                    }
+                mockMvc.post("/api/payments/$transactionId/confirm-settlement") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isServiceUnavailable() }
+                    header { string("Retry-After", "1") }
+                }
             }
         }
     }
@@ -338,6 +439,7 @@ class PaymentControllerTest {
                 every { paymentService.refundPayment(transactionId) } returns settledTransaction()
 
                 mockMvc.post("/api/payments/$transactionId/refund") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validRequest)
                 }.andExpect {
@@ -352,16 +454,54 @@ class PaymentControllerTest {
         }
 
         @Nested
+        inner class Idempotency {
+
+            @Test
+            fun `returns 400 when idempotency key is missing`() {
+                val transactionId = UUID.randomUUID()
+
+                mockMvc.post("/api/payments/$transactionId/refund") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(validRequest)
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.message") { value("Required header 'Idempotency-Key' is missing") }
+                }
+            }
+
+            @Test
+            fun `returns cached response on duplicate key without reprocessing`() {
+                val transactionId = UUID.randomUUID()
+                val cachedResponse = PaymentResponse.from(settledTransaction())
+                every { idempotencyService.resolve(
+                    eq(idempotencyKey), transactionId, PaymentResponse::class.java, any<() -> PaymentResponse>()
+                ) } returns cachedResponse
+
+                mockMvc.post("/api/payments/$transactionId/refund") {
+                    header("Idempotency-Key", idempotencyKey)
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(validRequest)
+                }.andExpect {
+                    status { isCreated() }
+                    jsonPath("$.transactionId") { value(cachedResponse.transactionId.toString()) }
+                }
+
+                verify(exactly = 0) { paymentService.refundPayment(any()) }
+            }
+        }
+
+        @Nested
         inner class FailureHandling {
 
             @Test
             fun `returns 400 when transaction ID is invalid`() {
                 val invalidId = "invalid-id"
 
-                mockMvc.post("/api/payments/$invalidId/refund")
-                    .andExpect {
-                        status { isBadRequest() }
-                    }
+                mockMvc.post("/api/payments/$invalidId/refund") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isBadRequest() }
+                }
             }
 
             @Test
@@ -370,10 +510,11 @@ class PaymentControllerTest {
                 every { paymentService.refundPayment(unknownId) } throws
                         EntityNotFoundException("Transaction not found: $unknownId")
 
-                mockMvc.post("/api/payments/$unknownId/refund")
-                    .andExpect {
-                        status { isNotFound() }
-                    }
+                mockMvc.post("/api/payments/$unknownId/refund") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isNotFound() }
+                }
             }
 
             @Test
@@ -382,10 +523,11 @@ class PaymentControllerTest {
                 every { paymentService.refundPayment(transactionId) } throws
                         InvalidTransactionStateException("Transaction is not in a valid state for refund")
 
-                mockMvc.post("/api/payments/$transactionId/refund")
-                    .andExpect {
-                        status { isUnprocessableContent() }
-                    }
+                mockMvc.post("/api/payments/$transactionId/refund") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isUnprocessableContent() }
+                }
             }
 
             @Test
@@ -394,11 +536,12 @@ class PaymentControllerTest {
                 every { paymentService.refundPayment(transactionId) } throws
                         ObjectOptimisticLockingFailureException(Transaction::class.java, "test-id")
 
-                mockMvc.post("/api/payments/$transactionId/refund")
-                    .andExpect {
-                        status { isServiceUnavailable() }
-                        header { string("Retry-After", "1") }
-                    }
+                mockMvc.post("/api/payments/$transactionId/refund") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isServiceUnavailable() }
+                    header { string("Retry-After", "1") }
+                }
             }
         }
     }
@@ -419,12 +562,42 @@ class PaymentControllerTest {
                 every { paymentService.reversePayment(transactionId, iban) } just Runs
 
                 mockMvc.post("/api/payments/$transactionId/reverse") {
-
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validReverseRequest)
                 }.andExpect {
                     status { isNoContent() }
                 }
+            }
+        }
+
+        @Nested
+        inner class Idempotency {
+
+            @Test
+            fun `returns 400 when Idempotency-Key header is missing`() {
+                mockMvc.post("/api/payments/${UUID.randomUUID()}/reverse") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(validReverseRequest)
+                }.andExpect {
+                    status { isBadRequest() }
+                }
+            }
+
+            @Test
+            fun `returns 204 on duplicate key without reprocessing`() {
+                val transactionId = UUID.randomUUID()
+                every { idempotencyService.exists(idempotencyKey) } returns true
+
+                mockMvc.post("/api/payments/$transactionId/reverse") {
+                    header("Idempotency-Key", idempotencyKey)
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(validReverseRequest)
+                }.andExpect {
+                    status { isNoContent() }
+                }
+
+                verify(exactly = 0) { paymentService.reversePayment(any(), any()) }
             }
         }
 
@@ -435,15 +608,17 @@ class PaymentControllerTest {
             fun `returns 400 when transaction ID is invalid`() {
                 val invalidId = "invalid-id"
 
-                mockMvc.post("/api/payments/$invalidId/reverse")
-                    .andExpect {
-                        status { isBadRequest() }
-                    }
+                mockMvc.post("/api/payments/$invalidId/reverse") {
+                    header("Idempotency-Key", idempotencyKey)
+                }.andExpect {
+                    status { isBadRequest() }
+                }
             }
 
             @Test
             fun `returns 400 when requester IBAN is blank`() {
                 mockMvc.post("/api/payments/${UUID.randomUUID()}/reverse") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validReverseRequest.copy(requesterIban = ""))
                 }.andExpect {
@@ -455,6 +630,7 @@ class PaymentControllerTest {
             @Test
             fun `returns 400 when requester IBAN is invalid`() {
                 mockMvc.post("/api/payments/${UUID.randomUUID()}/reverse") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validReverseRequest.copy(requesterIban = "INVALID"))
                 }.andExpect {
@@ -470,6 +646,7 @@ class PaymentControllerTest {
                         UnauthorizedOperationException("Only the owner of the source account can request a reversal")
 
                 mockMvc.post("/api/payments/$transactionId/reverse") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validReverseRequest)
                 }.andExpect {
@@ -484,6 +661,7 @@ class PaymentControllerTest {
                         EntityNotFoundException("Transaction not found: $unknownId")
 
                 mockMvc.post("/api/payments/$unknownId/reverse") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validReverseRequest)
                 }.andExpect {
@@ -498,6 +676,7 @@ class PaymentControllerTest {
                         InvalidTransactionStateException("Transaction is not in a valid state for reversal")
 
                 mockMvc.post("/api/payments/$transactionId/reverse") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validReverseRequest)
                 }.andExpect {
@@ -512,6 +691,7 @@ class PaymentControllerTest {
                         ObjectOptimisticLockingFailureException(Transaction::class.java, "test-id")
 
                 mockMvc.post("/api/payments/$transactionId/reverse") {
+                    header("Idempotency-Key", idempotencyKey)
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(validReverseRequest)
                 }.andExpect {

--- a/src/test/kotlin/nl/fayece/paymentprocessing/integration/AuditIT.kt
+++ b/src/test/kotlin/nl/fayece/paymentprocessing/integration/AuditIT.kt
@@ -1,0 +1,177 @@
+package nl.fayece.paymentprocessing.integration
+
+import nl.fayece.paymentprocessing.domain.Account
+import nl.fayece.paymentprocessing.domain.Iban
+import nl.fayece.paymentprocessing.domain.Transaction
+import nl.fayece.paymentprocessing.domain.TransactionStatus
+import nl.fayece.paymentprocessing.repositories.AccountRepository
+import nl.fayece.paymentprocessing.repositories.IdempotencyKeyRepository
+import nl.fayece.paymentprocessing.repositories.TransactionRepository
+import nl.fayece.paymentprocessing.repositories.TransactionStatusHistoryRepository
+import nl.fayece.paymentprocessing.util.toMoney
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.resttestclient.TestRestTemplate
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import java.math.BigDecimal
+import java.util.Currency
+import java.util.UUID
+
+class AuditIT : IntegrationTest() {
+
+    @Autowired
+    lateinit var restTemplate: TestRestTemplate
+
+    @Autowired
+    lateinit var accountRepository: AccountRepository
+
+    @Autowired
+    lateinit var transactionRepository: TransactionRepository
+
+    @Autowired
+    lateinit var statusHistoryRepository: TransactionStatusHistoryRepository
+
+    @Autowired
+    lateinit var idempotencyKeyRepository: IdempotencyKeyRepository
+
+    private val sourceIban = Iban.of("NL13TEST0123456789")
+    private val destinationIban = Iban.of("NL65TEST0987656789")
+    private val eur = Currency.getInstance("EUR")
+
+    private lateinit var sourceAccount: Account
+    private lateinit var destinationAccount: Account
+
+    @BeforeEach
+    fun setup() {
+        statusHistoryRepository.deleteAll()
+        transactionRepository.deleteAll()
+        idempotencyKeyRepository.deleteAll()
+        accountRepository.deleteAll()
+
+        val (src, dst) = accountRepository.saveAll(listOf(
+        Account(name = "Alice", iban = sourceIban, balance = BigDecimal("500.00").toMoney()),
+        Account(name = "Bob", iban = destinationIban, balance = BigDecimal("100.00").toMoney())
+        ))
+
+        sourceAccount = src
+        destinationAccount = dst
+    }
+
+    private fun validPayload(
+        sourceIban: String = this.sourceIban.value,
+        destinationIban: String = this.destinationIban.value,
+        amount: String = "100.00",
+        currency: String = "EUR"
+    ) = """
+        {
+            "sourceIban": "$sourceIban",
+            "destinationIban": "$destinationIban",
+            "amount": $amount,
+            "currency": "$currency"
+        }
+    """.trimIndent()
+
+    @Nested
+    inner class GetPaymentHistory {
+
+        @Test
+        fun `returns status history for a transaction in order`() {
+
+            val createResponse = restTemplate.postForEntity(
+                "/api/payments",
+                HttpEntity(validPayload(), HttpHeaders().apply {
+                    set("Idempotency-Key", UUID.randomUUID().toString())
+                    contentType = MediaType.APPLICATION_JSON
+                }),
+                Map::class.java
+            )
+
+            val transactionId = createResponse.body!!["transactionId"]
+
+            val response = restTemplate.getForEntity(
+                "/api/audit/payments/$transactionId/history",
+                List::class.java
+            )
+
+            assert(response.statusCode == HttpStatus.OK)
+            @Suppress("UNCHECKED_CAST")
+            val history = response.body as List<Map<String, Any>>
+            assert(history.size == 3)
+            assert(history[0]["status"] == "INITIATED")
+            assert(history[1]["status"] == "VALIDATED")
+            assert(history[2]["status"] == "QUEUED")
+        }
+
+        @Test
+        fun `returns 400 for invalid transaction ID`() {
+            val response = restTemplate.getForEntity(
+                "/api/audit/payments/invalid-id/history",
+                Map::class.java
+            )
+
+            assert(response.statusCode == HttpStatus.BAD_REQUEST)
+        }
+
+        @Test
+        fun `returns 404 for non-existing transaction`() {
+            val response = restTemplate.getForEntity(
+                "/api/audit/payments/${UUID.randomUUID()}/history",
+                Map::class.java
+            )
+
+            assert(response.statusCode == HttpStatus.NOT_FOUND)
+        }
+    }
+
+    @Nested
+    inner class GetFailedPayments {
+
+        @Test
+        fun `returns all failed transactions`() {
+
+            val createResponse = restTemplate.postForEntity(
+                "/api/payments",
+                HttpEntity(validPayload(amount = "9999.00"), HttpHeaders().apply {
+                    set("Idempotency-Key", UUID.randomUUID().toString())
+                    contentType = MediaType.APPLICATION_JSON
+                }),
+                Map::class.java
+            )
+
+            val succesful = restTemplate.postForEntity(
+                "/api/payments",
+                HttpEntity(validPayload(), HttpHeaders().apply {
+                    set("Idempotency-Key", UUID.randomUUID().toString())
+                    contentType = MediaType.APPLICATION_JSON
+                }),
+                Map::class.java
+            )
+
+            val successfulId = succesful.body!!["transactionId"]
+
+            val response = restTemplate.getForEntity("/api/audit/payments/failed", List::class.java)
+
+            assert(response.statusCode == HttpStatus.OK)
+            @Suppress("UNCHECKED_CAST")
+            val body = response.body as List<Map<String, Any>>
+            assert(body.size == 1)
+            assert(body[0]["transactionId"] != successfulId)
+        }
+
+        @Test
+        fun `returns empty list when no failed transactions exist`() {
+            val response = restTemplate.getForEntity(
+                "/api/audit/payments/failed",
+                List::class.java
+            )
+
+            assert(response.statusCode == HttpStatus.OK)
+            assert(response.body?.isEmpty() == true)
+        }
+    }
+}

--- a/src/test/kotlin/nl/fayece/paymentprocessing/integration/IntegrationTest.kt
+++ b/src/test/kotlin/nl/fayece/paymentprocessing/integration/IntegrationTest.kt
@@ -1,34 +1,15 @@
 package nl.fayece.paymentprocessing.integration
 
+import nl.fayece.paymentprocessing.TestcontainersConfiguration
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.postgresql.PostgreSQLContainer
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestRestTemplate
 @ActiveProfiles("test")
 @Testcontainers
-abstract class IntegrationTest {
-
-    companion object {
-        @Container
-        val postgres = PostgreSQLContainer("postgres:17.9-bookworm").apply {
-            withDatabaseName("paymentprocessing")
-            withUsername("test")
-            withPassword("test")
-        }
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun properties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url", postgres::getJdbcUrl)
-            registry.add("spring.datasource.username", postgres::getUsername)
-            registry.add("spring.datasource.password", postgres::getPassword)
-        }
-    }
-}
+@Import(TestcontainersConfiguration::class)
+abstract class IntegrationTest

--- a/src/test/kotlin/nl/fayece/paymentprocessing/integration/PaymentIT.kt
+++ b/src/test/kotlin/nl/fayece/paymentprocessing/integration/PaymentIT.kt
@@ -8,6 +8,7 @@ import nl.fayece.paymentprocessing.repositories.TransactionRepository
 import nl.fayece.paymentprocessing.repositories.TransactionStatusHistoryRepository
 import nl.fayece.paymentprocessing.util.toMoney
 import nl.fayece.paymentprocessing.domain.Account
+import nl.fayece.paymentprocessing.repositories.IdempotencyKeyRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,8 +19,9 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import java.math.BigDecimal
+import java.util.UUID
 
-class PaymentIT: IntegrationTest() {
+class PaymentIT() : IntegrationTest() {
 
     @Autowired
     lateinit var restTemplate: TestRestTemplate
@@ -33,6 +35,9 @@ class PaymentIT: IntegrationTest() {
     @Autowired
     lateinit var statusHistoryRepository: TransactionStatusHistoryRepository
 
+    @Autowired
+    lateinit var idempotencyKeyRepository: IdempotencyKeyRepository
+
     private val sourceIban = Iban.of("NL13TEST0123456789")
     private val destinationIban = Iban.of("NL65TEST0987656789")
 
@@ -40,6 +45,7 @@ class PaymentIT: IntegrationTest() {
     fun setup() {
         statusHistoryRepository.deleteAll()
         transactionRepository.deleteAll()
+        idempotencyKeyRepository.deleteAll()
         accountRepository.deleteAll()
 
         accountRepository.saveAll(listOf(
@@ -48,9 +54,11 @@ class PaymentIT: IntegrationTest() {
         ))
     }
 
-    private fun postPayment(body: String) = restTemplate.postForEntity(
+    private fun postPayment(body: String, idempotencyKey: String = UUID.randomUUID().toString()) = restTemplate.postForEntity(
         "/api/payments",
-        HttpEntity(body, HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }),
+        HttpEntity(body, HttpHeaders().apply {
+            set("Idempotency-Key", idempotencyKey)
+            contentType = MediaType.APPLICATION_JSON }),
         Map::class.java
     )
 
@@ -77,6 +85,9 @@ class PaymentIT: IntegrationTest() {
             @Test
             fun `returns 201 and transaction reaches QUEUED`() {
                 val response = postPayment(validPayload())
+
+                println("Status: ${response.statusCode}")
+                println("Body: ${response.body}")
 
                 assert(response.statusCode == HttpStatus.CREATED)
                 assert(response.body?.get("status") == "QUEUED")
@@ -114,6 +125,45 @@ class PaymentIT: IntegrationTest() {
                     TransactionStatus.VALIDATED,
                     TransactionStatus.QUEUED
                 ))
+            }
+        }
+
+        @Nested
+        inner class Idempotency {
+
+            @Test
+            fun `returns 400 when idempotency key is missing`() {
+                val response = restTemplate.postForEntity(
+                    "/api/payments",
+                    HttpEntity(validPayload(), HttpHeaders().apply { contentType = MediaType.APPLICATION_JSON }),
+                    Map::class.java
+                )
+
+                assert(response.statusCode == HttpStatus.BAD_REQUEST)
+            }
+
+            @Test
+            fun `duplicate submission returns same response without creating second transaction`() {
+                val key = UUID.randomUUID().toString()
+
+                val first = postPayment(validPayload(), idempotencyKey = key)
+                val second = postPayment(validPayload(), idempotencyKey = key)
+
+                assert(first.statusCode == HttpStatus.CREATED)
+                assert(second.statusCode == HttpStatus.CREATED)
+                assert(first.body?.get("transactionId") == second.body?.get("transactionId"))
+                assert(transactionRepository.count() == 1L)  // Check that only one transaction was created
+            }
+
+            @Test
+            fun `duplicate submission does not debit source account twice`() {
+                val key = UUID.randomUUID().toString()
+
+                postPayment(validPayload(), idempotencyKey = key)
+                postPayment(validPayload(), idempotencyKey = key)
+
+                val source = accountRepository.findByIban(sourceIban).get()
+                assert(source.balance == BigDecimal("400.00").toMoney())
             }
         }
 

--- a/src/test/kotlin/nl/fayece/paymentprocessing/services/PaymentServiceTest.kt
+++ b/src/test/kotlin/nl/fayece/paymentprocessing/services/PaymentServiceTest.kt
@@ -27,6 +27,7 @@ class PaymentServiceTest {
     private val accountRepository: AccountRepository = mockk()
     private val transactionRepository: TransactionRepository = mockk()
     private val statusHistoryRepository: TransactionStatusHistoryRepository = mockk()
+    private val transactionHistoryWriter: TransactionHistoryWriter = mockk()
     private lateinit var paymentService: PaymentService
 
     private val eur = Currency.getInstance("EUR")
@@ -41,7 +42,7 @@ class PaymentServiceTest {
     fun setup() {
         capturedHistory.clear()
 
-        paymentService = PaymentService(accountRepository, transactionRepository, statusHistoryRepository)
+        paymentService = PaymentService(accountRepository, transactionRepository, statusHistoryRepository, transactionHistoryWriter)
 
         sourceAccount = Account(name = "Alice", iban = sourceIban, balance = BigDecimal("550.00").toMoney())
         destinationAccount = Account(name = "Bob", iban = destinationIban, balance = BigDecimal("100.00").toMoney())
@@ -51,9 +52,17 @@ class PaymentServiceTest {
         every { accountRepository.saveAll(any<List<Account>>()) } returns listOf(sourceAccount, destinationAccount)
         every { transactionRepository.save(any()) } answers { firstArg() }
         every { statusHistoryRepository.save(capture(capturedHistory)) } answers { firstArg() }
-    }
 
-    // submitPayment
+        every { transactionHistoryWriter.recordFailure(any(), any()) } answers {
+            val transaction = args[0] as Transaction
+            val reason = args[1] as String?
+            capturedHistory.add(TransactionStatusHistory(
+                transaction = transaction,
+                status = TransactionStatus.FAILED,
+                reason = reason
+            ))
+        }
+    }
 
     @Nested
     inner class SubmitPayment {


### PR DESCRIPTION
This commit introduces idempotency on all endpoints. It also updates all tests to now expects the idempotency HTTP header.

Furthermore, a few extra changes are added:
- Cleaned up `GlobalExceptionHandler` to be less verbose
- Updated `PaymentIT` and new `AuditIT`
- Made `IntegrationTest` abstract without body, as it interfered with `TestcontainersConfiguration`
- Added Jackson mapping to solve issues related to Jackson with OffsetDateTime

To add to this, adding AuditIT signaled a bug in the logic: failed transactions were rolled back and never persisted to the history table, causing the call for all failed transactions to return 0. This has been fixed.